### PR TITLE
Implement a way to slow down the acceleration

### DIFF
--- a/src/Keyboardio-MouseKeys.cpp
+++ b/src/Keyboardio-MouseKeys.cpp
@@ -5,6 +5,8 @@
 #include "KeyboardioFirmware.h"
 
 uint8_t MouseKeys_::mouseMoveIntent;
+uint8_t MouseKeys_::accelDelay;
+uint8_t MouseKeys_::accelDelayCounter;
 
 void MouseKeys_::loopHook(bool postClear) {
     if (postClear) {
@@ -19,8 +21,12 @@ void MouseKeys_::loopHook(bool postClear) {
 
     int8_t moveX = 0, moveY = 0;
 
-    if (MouseWrapper.mouseActiveForCycles < 255)
-        MouseWrapper.mouseActiveForCycles++;
+    if (accelDelayCounter == accelDelay) {
+        if (MouseWrapper.mouseActiveForCycles < 255)
+            MouseWrapper.mouseActiveForCycles++;
+        accelDelayCounter = 0;
+    } else
+        accelDelayCounter++;
 
     if (mouseMoveIntent & KEY_MOUSE_UP)
         moveY = -1;

--- a/src/Keyboardio-MouseKeys.h
+++ b/src/Keyboardio-MouseKeys.h
@@ -8,9 +8,11 @@ class MouseKeys_ : public KeyboardioPlugin {
     MouseKeys_ (void);
 
     virtual void begin(void) final;
+    static uint8_t accelDelay;
 
  private:
     static uint8_t mouseMoveIntent;
+    static uint8_t accelDelayCounter;
 
     static void loopHook(bool postClear);
     static Key eventHandlerHook(Key mappedKey, byte row, byte col, uint8_t keyState);


### PR DESCRIPTION
On the Shortcut, the thumb sticks are awesome for mousing around, but the acceleration speed is too high (it's not so on the Model01, though!). Because the optimal speed varies from person to person, from keyboard to keyboard, make it runtime changeable.